### PR TITLE
Multi object recurrences

### DIFF
--- a/localized_recurrence/models.py
+++ b/localized_recurrence/models.py
@@ -49,9 +49,11 @@ class LocalizedRecurrenceQuerySet(models.query.QuerySet):
                 recurrence.save()
         else:
             for recurrence in self:
+                ct = ContentType.objects.get_for_model(for_object)
                 obj, created = RecurrenceForObject.objects.get_or_create(
                     recurrence=recurrence,
-                    content_object=for_object
+                    content_type=ct,
+                    object_id=for_object.id
                 )
                 obj.next_scheduled = recurrence.utc_of_next_schedule(time)
                 obj.previous_scheduled = time
@@ -66,7 +68,7 @@ class LocalizedRecurrenceManager(models.Manager):
         """
         Written to allow both:
             - LocalizedRecurrence.objects.update_schedule()
-            - LocalizedRecurrence.get(id=my_recurrence).update_schedule()
+            - LocalizedRecurrence.filter(id=my_recurrence.id).update_schedule()
         """
         return getattr(self.get_queryset(), name)
 

--- a/localized_recurrence/tests/models_tests.py
+++ b/localized_recurrence/tests/models_tests.py
@@ -1,9 +1,10 @@
 import unittest
 from datetime import datetime, timedelta
 
+from django.contrib.contenttypes.models import ContentType
 import pytz
 
-from ..models import LocalizedRecurrence, LocalizedRecurrenceQuerySet, replace_with_offset
+from ..models import LocalizedRecurrence, LocalizedRecurrenceQuerySet, RecurrenceForObject, replace_with_offset
 
 
 class Test_LocalizedRecurrenceQuerySet(unittest.TestCase):
@@ -50,6 +51,35 @@ class Test_LocalizedRecurrenceQuerySet_update_schedule(unittest.TestCase):
         time = datetime(year=2013, month=5, day=20, hour=15, minute=3)
         LocalizedRecurrence.objects.update_schedule(time=time)
         self.assertTrue(all(r.next_scheduled > time for r in LocalizedRecurrence.objects.all()))
+
+    def test_update_schedule_for_object_creates(self):
+        lr_day2 = LocalizedRecurrence.objects.create(
+            interval='DAY',
+            offset=timedelta(hours=12),
+            timezone=pytz.timezone('US/Eastern')
+        )
+        # we just re-use lr_day2 here because it's convenient, not
+        # because it's a sensible object.
+        LocalizedRecurrence.objects.filter(id=lr_day2.id).update_schedule(for_object=lr_day2)
+        expected = 1
+        num_recurrence_for_obj = RecurrenceForObject.objects.count()
+        self.assertEqual(num_recurrence_for_obj, expected)
+
+    def test_updates_correctly(self):
+        time = datetime(year=2013, month=5, day=20, hour=15, minute=3)
+        lr_day2 = LocalizedRecurrence.objects.create(
+            interval='DAY',
+            offset=timedelta(hours=12),
+            timezone=pytz.timezone('US/Eastern')
+        )
+        # again, re-using lr_day2 here because it's convenient.
+        LocalizedRecurrence.objects.filter(id=lr_day2.id).update_schedule(
+            for_object=lr_day2, time=time)
+        ct = ContentType.objects.get_for_model(lr_day2)
+        individual_recurrence = lr_day2.recurrenceforobject_set.get(
+            object_id=lr_day2.id, content_type=ct)
+        self.assertGreater(individual_recurrence.next_scheduled, time)
+        self.assertEqual(individual_recurrence.previous_scheduled, time)
 
 
 class Test_LocalizedRecurrence(unittest.TestCase):


### PR DESCRIPTION
@wesleykendall This pull request adds support for tracking multiple 'objects' with a single recurrence. It does this by adding an additional model, `RecurrenceForObject`, which includes a foreign key to the recurrence, and a generic foreign key for whatever objects you want associated with that recurrence.

The intention is to make group subscriptions to triggers a lot easier. Because we didn't have group subscriptions worked out yet, we ended up with some hacks in triggers to keep things running, which introduced dependencies on ambition.
