### PR TITLE
Support USE_TZ In Django Configuration And Remove Potential Runtime Warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ venv/
 
 # Pycharm
 .idea/
+
+# VS Code
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.linting.enabled": false
+}

--- a/localized_recurrence/fields.py
+++ b/localized_recurrence/fields.py
@@ -109,6 +109,10 @@ class DurationField(IntegerField):
         return str(time_delta_value)
 
 
+DAYS_RE = re.compile(r"(?P<days>-?[0-9]*) days?, (?P<hours>[0-9]+):(?P<minutes>[0-9]+):(?P<seconds>[0-9]+\.?[0-9]*)")
+NO_DAYS_RE = re.compile(r"(?P<hours>[0-9]+):(?P<minutes>[0-9]+):(?P<seconds>[0-9]+\.?[0-9]*)")
+
+
 def parse_timedelta_string(string):
     """Parses strings from datetime.timedelta.__str__.
 
@@ -118,10 +122,8 @@ def parse_timedelta_string(string):
     datetime.timedelta.__str__ returns a string in the form [D day[s],
     ][H]H:MM:SS[.UUUUUU], where D is negative for negative t.
     """
-    days_re = "(?P<days>-?[0-9]*) days?, (?P<hours>[0-9]+):(?P<minutes>[0-9]+):(?P<seconds>[0-9]+\.?[0-9]*)"
-    no_days_re = "(?P<hours>[0-9]+):(?P<minutes>[0-9]+):(?P<seconds>[0-9]+\.?[0-9]*)"
-    match_days = re.match(days_re, string)
-    match_no_days = re.match(no_days_re, string)
+    match_days = re.match(DAYS_RE, string)
+    match_no_days = re.match(NO_DAYS_RE, string)
     if match_days:
         return timedelta(**{k: float(v) for k, v in match_days.groupdict().items()})
     elif match_no_days:


### PR DESCRIPTION
This code honors `USE_TZ=True` (or `False`) as follows:

If `USE_TZ` is set to `True`, store datetimes as aware with respect to the `TIME_ZONE` setting value (by using Django's `timezone.make_aware` function).

If `USE_TZ` is set to `False`, store datetimes as naive (what the code is currently doing).

This potentially removes tons of testing/runtime warnings where Django does the casting from naive to aware itself, and also better honors the backend's preferred timezone to store things in if specified.